### PR TITLE
Show flatpak/snap apps in auto-start list by searching $XDG-DATA-DIRS

### DIFF
--- a/src/Startup/Utils.vala
+++ b/src/Startup/Utils.vala
@@ -23,27 +23,34 @@ using Startup;
 namespace Startup.Utils {
 
     const string AUTOSTART_DIR = "autostart";
+    const string APPLICATION_DIRS = "applications";
 
     string[] get_application_files () {
-        var app_dir = Utils.get_application_dir ();
-        var enumerator = new Backend.DesktopFileEnumerator (app_dir);
+        var app_dirs = Utils.get_application_dirs ();
+        var enumerator = new Backend.DesktopFileEnumerator (app_dirs);
         return enumerator.get_desktop_files ();
     }
 
     string[] get_auto_start_files () {
         var startup_dir = Utils.get_user_startup_dir ();
-        var enumerator = new Backend.DesktopFileEnumerator (startup_dir);
+        var enumerator = new Backend.DesktopFileEnumerator ({ startup_dir });
         return enumerator.get_desktop_files ();
     }
-    
-    string get_application_dir () {
-        var app_dir = "/usr/share/applications/";
-        
-        if (FileUtils.test (app_dir, FileTest.EXISTS))
-            return app_dir;
+
+    string[] get_application_dirs () {
+        string[] result = {};
+
+        var data_dirs = Environment.get_system_data_dirs ();
+        foreach (var data_dir in data_dirs) {
+            var app_dir = Path.build_filename (data_dir, APPLICATION_DIRS);
+            if (FileUtils.test (app_dir, FileTest.EXISTS))
+                result += app_dir;
+        }
+
+        if (result.length == 0)
+            warning ("No application directories found");
             
-        warning (@"Application directory '$app_dir' does not exist");
-        return "";
+        return result;
     }
 
     string get_user_startup_dir () {


### PR DESCRIPTION
Hi there :wave: I've started installing some apps on elementary via snap/flatpak since I didn't want to mess with PPAs. However, I couldn't add Spotify to the list of auto-starting apps because its desktop file is not located in `/usr/share/applications`.

So I've changed the app search in the "Startup" tab to search in all app directories found in `$XDG_DATA_DIRS`/`GLib.Environment.get_system_data_dirs` instead. It seems other parts of eOS use Synapse(?) to look for apps, such as the application menu, but I think the list is already better than a single hardcoded path (unless there's a reason for limiting the selection?).

![bildschirmfoto von 2018-02-02 18 14 14](https://user-images.githubusercontent.com/70772/35745837-ed4cc902-0844-11e8-8d7f-af8afd0a18b1.png)

Let me know what you think.