### PR TITLE
Limit texts length in app chooser

### DIFF
--- a/src/Startup/Widgets/AppChooser.vala
+++ b/src/Startup/Widgets/AppChooser.vala
@@ -41,7 +41,7 @@ public class Startup.Widgets.AppChooser : Gtk.Popover {
         var scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.height_request = 200;
         scrolled.width_request = 500;
-        scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
+        scrolled.vscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
 
         list = new Gtk.ListBox ();
         list.expand = true;

--- a/src/Startup/Widgets/AppChooser.vala
+++ b/src/Startup/Widgets/AppChooser.vala
@@ -40,7 +40,7 @@ public class Startup.Widgets.AppChooser : Gtk.Popover {
 
         var scrolled = new Gtk.ScrolledWindow (null, null);
         scrolled.height_request = 200;
-        scrolled.width_request = 250;
+        scrolled.width_request = 500;
         scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
 
         list = new Gtk.ListBox ();

--- a/src/Startup/Widgets/AppChooserRow.vala
+++ b/src/Startup/Widgets/AppChooserRow.vala
@@ -39,13 +39,11 @@ public class Startup.Widgets.AppChooserRow : Gtk.Grid {
         app_name.get_style_context ().add_class ("h3");
         app_name.xalign = 0;
         app_name.ellipsize = Pango.EllipsizeMode.END;
-        app_name.max_width_chars = 50;
 
         var app_comment = new Gtk.Label ("<span font_size='small'>" + app_info.comment + "</span>");
         app_comment.xalign = 0;
         app_comment.use_markup = true;
         app_comment.ellipsize = Pango.EllipsizeMode.END;
-        app_comment.max_width_chars = 60;
 
         margin = 6;
         margin_end = 12;

--- a/src/Startup/Widgets/AppChooserRow.vala
+++ b/src/Startup/Widgets/AppChooserRow.vala
@@ -38,10 +38,14 @@ public class Startup.Widgets.AppChooserRow : Gtk.Grid {
         var app_name = new Gtk.Label (app_info.name);
         app_name.get_style_context ().add_class ("h3");
         app_name.xalign = 0;
+        app_name.ellipsize = Pango.EllipsizeMode.END;
+        app_name.max_width_chars = 40;
 
         var app_comment = new Gtk.Label ("<span font_size='small'>" + app_info.comment + "</span>");
         app_comment.xalign = 0;
         app_comment.use_markup = true;
+        app_comment.ellipsize = Pango.EllipsizeMode.END;
+        app_comment.max_width_chars = 40;
 
         margin = 6;
         margin_end = 12;

--- a/src/Startup/Widgets/AppChooserRow.vala
+++ b/src/Startup/Widgets/AppChooserRow.vala
@@ -39,13 +39,13 @@ public class Startup.Widgets.AppChooserRow : Gtk.Grid {
         app_name.get_style_context ().add_class ("h3");
         app_name.xalign = 0;
         app_name.ellipsize = Pango.EllipsizeMode.END;
-        app_name.max_width_chars = 40;
+        app_name.max_width_chars = 50;
 
         var app_comment = new Gtk.Label ("<span font_size='small'>" + app_info.comment + "</span>");
         app_comment.xalign = 0;
         app_comment.use_markup = true;
         app_comment.ellipsize = Pango.EllipsizeMode.END;
-        app_comment.max_width_chars = 40;
+        app_comment.max_width_chars = 60;
 
         margin = 6;
         margin_end = 12;


### PR DESCRIPTION
See: https://elementaryos.stackexchange.com/questions/14929/add-startup-app-menu-broken

If there is a better way to limit the text length, please let me know. Maybe there is a way to enforce a width for the Popover?