### PR TITLE
Adds support for application-menu's web-search plugin

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -14,3 +14,4 @@ src/Startup/Widgets/AppChooserRow.vala
 src/Startup/Widgets/AppChooser.vala
 src/Defaults/Utils.vala
 src/Defaults/DefaultPlug.vala
+src/WebSearch/WebSearch.vala

--- a/po/applications-plug.pot
+++ b/po/applications-plug.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: applications-plug\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-15 20:03-0500\n"
+"POT-Creation-Date: 2019-01-27 13:39-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,61 +17,69 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Plug.vala:37
+#: src/Plug.vala:39
 msgid "Applications"
 msgstr ""
 
-#: src/Plug.vala:38
+#: src/Plug.vala:40
 msgid "Manage default and startup applications"
 msgstr ""
 
-#: src/Plug.vala:54 src/Plug.vala:99 src/Plug.vala:100 src/Plug.vala:101
-#: src/Plug.vala:102 src/Plug.vala:103 src/Plug.vala:104 src/Plug.vala:105
-#: src/Plug.vala:106
+#: src/Plug.vala:57 src/Plug.vala:106 src/Plug.vala:107 src/Plug.vala:108
+#: src/Plug.vala:109 src/Plug.vala:110 src/Plug.vala:111 src/Plug.vala:112
+#: src/Plug.vala:113
 msgid "Default"
 msgstr ""
 
-#: src/Plug.vala:55 src/Plug.vala:96
+#: src/Plug.vala:58 src/Plug.vala:101
 msgid "Startup"
 msgstr ""
 
-#: src/Plug.vala:97
-msgid "Default Apps"
-msgstr ""
-
-#: src/Plug.vala:98
-msgid "Default Application"
-msgstr ""
-
-#: src/Plug.vala:99
-msgid "Web Browser"
-msgstr ""
-
-#: src/Plug.vala:100
-msgid "Email Client"
-msgstr ""
-
-#: src/Plug.vala:101
-msgid "Calendar"
+#: src/Plug.vala:59 src/Plug.vala:103 src/Plug.vala:104
+msgid "Web Search"
 msgstr ""
 
 #: src/Plug.vala:102
-msgid "Video Player"
-msgstr ""
-
-#: src/Plug.vala:103
-msgid "Music Player"
+msgid "Default Apps"
 msgstr ""
 
 #: src/Plug.vala:104
-msgid "Text Editor"
+msgid "Search Engine"
 msgstr ""
 
 #: src/Plug.vala:105
-msgid "Image Viewer"
+msgid "Default Application"
 msgstr ""
 
 #: src/Plug.vala:106
+msgid "Web Browser"
+msgstr ""
+
+#: src/Plug.vala:107
+msgid "Email Client"
+msgstr ""
+
+#: src/Plug.vala:108
+msgid "Calendar"
+msgstr ""
+
+#: src/Plug.vala:109
+msgid "Video Player"
+msgstr ""
+
+#: src/Plug.vala:110
+msgid "Music Player"
+msgstr ""
+
+#: src/Plug.vala:111
+msgid "Text Editor"
+msgstr ""
+
+#: src/Plug.vala:112
+msgid "Image Viewer"
+msgstr ""
+
+#: src/Plug.vala:113
 msgid "File Browser"
 msgstr ""
 
@@ -138,4 +146,60 @@ msgstr ""
 
 #: src/Defaults/DefaultPlug.vala:83
 msgid "File Browser:"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:58
+msgid "DuckDuckGo (default)"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:59
+msgid "Baidu"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:60
+msgid "Bing"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:61
+msgid "Google"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:62
+msgid "Yahoo!"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:63
+msgid "Yandex"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:64
+msgid "Custom"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:79
+msgid "https://example.com/?q={query}"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:84
+msgid ""
+"The search URL must be a valid URL containing <b>{query}</b> wherever the "
+"search terms should appear, e.g. https://example.com/?q={query}"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:96
+msgid "Custom search URL:"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:110
+msgid ""
+"When searching with the Applications Menu, show an option to launch a web "
+"search in your browser."
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:112
+msgid "Search the web with:"
+msgstr ""
+
+#: src/WebSearch/WebSearch.vala:167
+msgid "Enable Web Search:"
 msgstr ""

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -23,6 +23,7 @@ public class ApplicationsPlug : Switchboard.Plug {
 
     private const string DEFAULTS = "defaults";
     private const string STARTUP = "startup";
+    private const string WEB_SEARCH = "web_search";
 
     private Gtk.Grid grid;
     private Gtk.Stack stack;
@@ -32,6 +33,7 @@ public class ApplicationsPlug : Switchboard.Plug {
         settings.set ("applications", null);
         settings.set ("applications/defaults", DEFAULTS);
         settings.set ("applications/startup", STARTUP);
+        settings.set ("applications/websearch", WEB_SEARCH);
         Object (category: Category.PERSONAL,
                 code_name: "personal-pantheon-applications",
                 display_name: _("Applications"),
@@ -47,12 +49,14 @@ public class ApplicationsPlug : Switchboard.Plug {
 
         var defaults_plug = new Defaults.Plug ();
         var startup_plug = new Startup.Plug ();
+        var websearch_plug = new WebSearch.Plug ();
 
         stack = new Gtk.Stack ();
         stack.expand = true;
 
         stack.add_titled (defaults_plug, DEFAULTS, _("Default"));
         stack.add_titled (startup_plug, STARTUP, _("Startup"));
+        stack.add_titled (websearch_plug, WEB_SEARCH, _("Web Search"));
 
         var stack_switcher = new Gtk.StackSwitcher ();
         stack_switcher.halign = Gtk.Align.CENTER;
@@ -72,17 +76,18 @@ public class ApplicationsPlug : Switchboard.Plug {
     }
 
     public override void shown () {
-    
+
     }
 
     public override void hidden () {
-    
+
     }
 
     public override void search_callback (string location) {
         switch (location) {
             case STARTUP:
             case DEFAULTS:
+            case WEB_SEARCH:
                 stack.set_visible_child_name (location);
                 break;
             default:
@@ -92,9 +97,11 @@ public class ApplicationsPlug : Switchboard.Plug {
     }
 
     public override async Gee.TreeMap<string, string> search (string search) {
-        var search_results = new Gee.TreeMap<string, string> ((GLib.CompareDataFunc<string>)strcmp, (Gee.EqualDataFunc<string>)str_equal);
+        var search_results = new Gee.TreeMap<string, string> ((a, b) => strcmp (a, b), (a, b) => str_equal (a, b));
         search_results.set ("%s → %s".printf (display_name, _("Startup")), STARTUP);
         search_results.set ("%s → %s".printf (display_name, _("Default Apps")), DEFAULTS);
+        search_results.set ("%s → %s".printf (display_name, _("Web Search")), WEB_SEARCH);
+        search_results.set ("%s → %s → %s".printf (display_name, _("Web Search"), _("Search Engine")), WEB_SEARCH);
         search_results.set ("%s → %s".printf (display_name, _("Default Application")), DEFAULTS);
         search_results.set ("%s → %s → %s".printf (display_name, _("Default"), _("Web Browser")), DEFAULTS);
         search_results.set ("%s → %s → %s".printf (display_name, _("Default"), _("Email Client")), DEFAULTS);

--- a/src/WebSearch/WebSearch.vala
+++ b/src/WebSearch/WebSearch.vala
@@ -1,0 +1,211 @@
+/*
+* Copyright (c) 2011-2019 elementary LLC. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Matthew Olenik <olenikm@gmail.com>
+*/
+
+
+public class WebSearch.Plug : Gtk.Grid {
+    class Choice {
+        public string text;
+        public int sort_id;
+    }
+
+    private Settings gsettings = new Settings ("io.elementary.desktop.wingpanel.applications-menu");
+    private static Gee.HashMap<string, Choice> search_engine_choices;
+
+    private Gtk.Entry custom_search_url_entry;
+    private Gtk.Label custom_error_label;
+    private Gtk.ComboBox engine_choice;
+    private Gtk.ListStore store;
+    private Gtk.Switch enabled_switch;
+    private Gtk.Grid search_selector_grid;
+    private Gtk.Grid custom_box;
+
+    private const string DEFAULT_ENGINE_ID = "duckduckgo";
+    private const string CUSTOM_ENGINE_ID = "custom";
+    private const string STRAWBERRY = "#c6262e";  // From elementary human interface guidelines
+    private const int CUSTOM_URL_WIDTH = 55;
+    private Regex url_valid_regex;
+
+    construct {
+        try {
+            url_valid_regex = new Regex("""https?:\/\/.*\{query\}""");
+        } catch (RegexError e) {
+            error (e.message);
+        }
+        /*
+        * sort_id is used to pre-sort the items. We want alphabetical except for the default (placed at the top),
+        * and custom (placed at the bottom). The reasoning being that it "feels right" to have the default option
+        * most visible at the top, and custom, being the least likely to be used, at the bottom.
+        */
+        search_engine_choices = new Gee.HashMap<string, Choice> ();
+        search_engine_choices["duckduckgo"] = new Choice () { sort_id = 0, text = _("DuckDuckGo (default)") };
+        search_engine_choices["baidu"] = new Choice () { sort_id = 1, text = _("Baidu") };
+        search_engine_choices["bing"] = new Choice () { sort_id = 2, text = _("Bing") };
+        search_engine_choices["google"] = new Choice () { sort_id = 3, text = _("Google") };
+        search_engine_choices["yahoo"] = new Choice () { sort_id = 4, text = _("Yahoo!") };
+        search_engine_choices["yandex"] = new Choice () { sort_id = 5, text = _("Yandex") };
+        search_engine_choices[CUSTOM_ENGINE_ID] = new Choice () { sort_id = 6, text = _("Custom") };
+
+        halign = Gtk.Align.CENTER;
+        row_spacing = 24;
+        margin = 24;
+        margin_top = 48;
+
+        /* Container that groups custom URL label, entry, and error label widgets. */
+        custom_box = new Gtk.Grid () {
+            row_spacing = 5,
+            column_spacing = 10,
+            visible = false,
+            no_show_all = true
+        };
+        custom_search_url_entry = new Gtk.Entry () {
+            placeholder_text = _("https://example.com/?q={query}"),
+            width_chars = CUSTOM_URL_WIDTH,
+            max_width_chars = CUSTOM_URL_WIDTH
+        };
+        var error_text =
+            _("The search URL must be a valid URL containing <b>{query}</b> wherever the search terms should appear, e.g. https://example.com/?q={query}");
+        custom_error_label = new Gtk.Label (error_text) {
+            use_markup = true,
+            wrap = true,
+            wrap_mode = Pango.WrapMode.WORD,
+            width_chars = CUSTOM_URL_WIDTH,
+            max_width_chars = CUSTOM_URL_WIDTH,
+            halign = Gtk.Align.START,
+            no_show_all = true,
+            visible = false
+        };
+        custom_error_label.get_style_context ().add_class (Granite.STYLE_CLASS_ACCENT);
+        var custom_search_label = new Gtk.Label (_("Custom search URL:")) {
+            halign = Gtk.Align.START,
+            hexpand = false
+        };
+        custom_box.attach (custom_search_label, 0, 0, 1, 1);
+        custom_box.attach (custom_search_url_entry, 1, 0, 1, 1);
+        custom_box.attach (custom_error_label, 1, 1, 1, 1);
+
+        /* Container to hold label + combobox */
+        search_selector_grid = new Gtk.Grid () {
+            halign = Gtk.Align.START,
+            column_spacing = 10
+        };
+
+        var summary_label = new Gtk.Label (_("When searching with the Applications Menu, show an option to launch a web search in your browser."));
+
+        var choice_label = new Gtk.Label (_("Search the web with:"));
+        search_selector_grid.attach (choice_label, 0, 0, 1, 1);
+
+        /* This structure corresponds to the search_engine_choices map structure. */
+        store = new Gtk.ListStore (3, typeof (string), typeof (string), typeof (int));
+        store.set_sort_column_id (2, Gtk.SortType.ASCENDING);
+
+        /* Populate combobox with vales from search_engine_choices structure. */
+        Gtk.TreeIter iter;
+        foreach (var choice in search_engine_choices.entries) {
+            store.append (out iter);
+            store.set (iter, 0, choice.key, 1, choice.value.text, 2, choice.value.sort_id);
+        }
+
+        engine_choice = new Gtk.ComboBox.with_model (store) {
+            id_column = 0  // Make sure to sort according to the sort_id property
+        };
+        search_selector_grid.attach (engine_choice, 1, 0, 1, 1);
+        var renderer = new Gtk.CellRendererText ();
+        engine_choice.pack_start (renderer, true);
+        engine_choice.add_attribute (renderer, "text", 1);
+
+        gsettings.bind ("web-search-engine-id", engine_choice, "active_id", SettingsBindFlags.DEFAULT);
+        gsettings.bind ("web-search-custom-url", custom_search_url_entry, "text", SettingsBindFlags.DEFAULT);
+
+        /* Fall back to the default if a bad ID is found. This shouldn't happen unless the gsettings were tampered with. */
+        if (engine_choice.active_id == null || engine_choice.active_id.chomp () == "") {
+            engine_choice.active_id = DEFAULT_ENGINE_ID;
+        }
+
+        if (engine_choice.active_id == CUSTOM_ENGINE_ID) {
+            widget_set_visible (custom_box, true);
+        } else {
+            widget_set_visible (custom_box, false);
+        }
+
+        engine_choice.changed.connect (() => {
+            Gtk.TreeIter i;
+            engine_choice.get_active_iter (out i);
+            Value id;
+            store.get_value (i, 0, out id);
+            if ((string) id == CUSTOM_ENGINE_ID) {
+                widget_set_visible (custom_box, true);
+            } else {
+                widget_set_visible (custom_box, false);
+            }
+        });
+
+        custom_search_url_entry.changed.connect (check_custom_error);
+        check_custom_error ();
+
+        var enabled_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 10) {
+            halign = Gtk.Align.START
+        };
+
+        var enabled_label = new Gtk.Label (_("Enable Web Search:"));
+        enabled_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+
+        enabled_switch = new Gtk.Switch ();
+        gsettings.bind ("web-search-enabled", enabled_switch, "active", SettingsBindFlags.DEFAULT);
+        set_form_sensitive (enabled_switch.active);
+        enabled_switch.state_set.connect (set_form_sensitive);
+
+        enabled_box.pack_start (enabled_label, false, false, 0);
+        enabled_box.pack_start (enabled_switch, false, false, 0);
+
+        attach (enabled_box, 0, 0, 1, 1);
+        attach (summary_label, 0, 1, 1, 1);
+        attach (search_selector_grid, 0, 2, 1, 1);
+        attach (custom_box, 0, 3, 1, 1);
+
+        show_all ();
+    }
+
+    /* Gray out parts of the form when search is enabled or disabled */
+    private bool set_form_sensitive (bool sensitive) {
+        custom_box.sensitive = sensitive;
+        search_selector_grid.sensitive = sensitive;
+        return false;  // Do not block default handler
+    }
+
+    private void check_custom_error () {
+        if (!url_valid_regex.match(custom_search_url_entry.text)) {
+            widget_set_visible (custom_error_label, true);
+        } else {
+            widget_set_visible (custom_error_label, false);
+        }
+    }
+
+    private static void widget_set_visible (Gtk.Widget w, bool visible) {
+        w.no_show_all = !visible;
+        w.visible = visible;
+        if (visible) {
+            w.show_all ();
+        }
+    }
+
+    public Plug () {
+    }
+}

--- a/src/WebSearch/WebSearch.vala
+++ b/src/WebSearch/WebSearch.vala
@@ -164,8 +164,10 @@ public class WebSearch.Plug : Gtk.Grid {
             halign = Gtk.Align.START
         };
 
-        var enabled_label = new Gtk.Label (_("Enable Web Search:"));
-        enabled_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+        var enabled_label = new Gtk.Label (null) {
+            label = "<span size='large'>" + _("Enable Web Search:") + "</span>",
+            use_markup = true
+        };
 
         enabled_switch = new Gtk.Switch ();
         gsettings.bind ("web-search-enabled", enabled_switch, "active", SettingsBindFlags.DEFAULT);

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,8 @@ plug_files = files(
     'Startup/Widgets/AppChooserRow.vala',
     'Startup/Widgets/AppChooser.vala',
     'Defaults/Utils.vala',
-    'Defaults/DefaultPlug.vala'
+    'Defaults/DefaultPlug.vala',
+    'WebSearch/WebSearch.vala'
 )
 
 switchboard_dep = dependency('switchboard-2.0')


### PR DESCRIPTION
Has built-in support for commonly used search engines as well as a
custom URL field. See the corresponding PR in application-menu.

![search](https://user-images.githubusercontent.com/440961/51807549-e6f97100-223c-11e9-8b4e-8d2408bd93df.png)
![switchboard1](https://user-images.githubusercontent.com/440961/51807553-ec56bb80-223c-11e9-97ba-900ae51e4966.png)
![switchboard2](https://user-images.githubusercontent.com/440961/51807550-e95bcb00-223c-11e9-8d63-4fc4eeb997da.png)