### PR TITLE
Fix snap icons in AppChooserRow and AppRow

### DIFF
--- a/src/Startup/Utils.vala
+++ b/src/Startup/Utils.vala
@@ -98,8 +98,6 @@ namespace Startup.Utils {
         var image = new Gtk.Image ();
         image.pixel_size = pixel_size;
 
-        debug (app_info.icon);
-
         if (icon_theme.lookup_by_gicon (icon, pixel_size, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
             try {
                 var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon)

--- a/src/Startup/Utils.vala
+++ b/src/Startup/Utils.vala
@@ -102,7 +102,8 @@ namespace Startup.Utils {
 
         if (icon_theme.lookup_by_gicon (icon, pixel_size, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
             try {
-                var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon).scale_simple (pixel_size, pixel_size, Gdk.InterpType.BILINEAR);
+                var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon)
+                    .scale_simple (pixel_size, pixel_size, Gdk.InterpType.BILINEAR);
                 image = new Gtk.Image.from_pixbuf (pixbuf);
             } catch (GLib.Error err) {
                 icon = new ThemedIcon (FALLBACK_ICON);

--- a/src/Startup/Utils.vala
+++ b/src/Startup/Utils.vala
@@ -77,13 +77,42 @@ namespace Startup.Utils {
     
     const string FALLBACK_ICON = "application-default-icon";
 
-    string create_icon (Entity.AppInfo app_info) {
+    Gtk.Image create_icon (Entity.AppInfo app_info, Gtk.IconSize icon_size) {
+        var icon = new ThemedIcon.with_default_fallbacks (app_info.icon);
         var icon_theme = Gtk.IconTheme.get_default ();
 
-        if (icon_theme.has_icon (app_info.icon)) {
-            return app_info.icon;
-        } else {
-            return FALLBACK_ICON;
+        int pixel_size;
+
+        switch (icon_size) {
+            case Gtk.IconSize.DIALOG:
+                pixel_size = 48;
+                break;
+            case Gtk.IconSize.DND:
+                pixel_size = 32;
+                break;
+            default:
+                pixel_size = 32;
+                break;
         }
+
+        var image = new Gtk.Image ();
+        image.pixel_size = pixel_size;
+
+        debug (app_info.icon);
+
+        if (icon_theme.lookup_by_gicon (icon, pixel_size, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
+            try {
+                var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon).scale_simple (pixel_size, pixel_size, Gdk.InterpType.BILINEAR);
+                image = new Gtk.Image.from_pixbuf (pixbuf);
+            } catch (GLib.Error err) {
+                icon = new ThemedIcon (FALLBACK_ICON);
+                image = new Gtk.Image.from_gicon (icon, icon_size);
+                debug (err.message);
+            }
+        } else {
+            image = new Gtk.Image.from_gicon (icon, icon_size);
+        }
+
+        return image;
     }
 }

--- a/src/Startup/Utils.vala
+++ b/src/Startup/Utils.vala
@@ -96,7 +96,6 @@ namespace Startup.Utils {
         }
 
         var image = new Gtk.Image ();
-        image.pixel_size = pixel_size;
 
         if (icon_theme.lookup_by_gicon (icon, pixel_size, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
             try {
@@ -111,6 +110,8 @@ namespace Startup.Utils {
         } else {
             image = new Gtk.Image.from_gicon (icon, icon_size);
         }
+
+        image.pixel_size = pixel_size;
 
         return image;
     }

--- a/src/Startup/Widgets/AppChooserRow.vala
+++ b/src/Startup/Widgets/AppChooserRow.vala
@@ -41,7 +41,7 @@ public class Startup.Widgets.AppChooserRow : Gtk.Grid {
         if (icon_theme.lookup_by_gicon (icon, 32, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
             try {
                 var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon).scale_simple (32, 32, Gdk.InterpType.BILINEAR);
-                image = new Gtk.Image.from_pixbuf ( pixbuf );
+                image = new Gtk.Image.from_pixbuf (pixbuf);
             } catch (GLib.Error err) {
                 icon = new ThemedIcon (FALLBACK_ICON);
                 image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DND);

--- a/src/Startup/Widgets/AppChooserRow.vala
+++ b/src/Startup/Widgets/AppChooserRow.vala
@@ -25,31 +25,12 @@ public class Startup.Widgets.AppChooserRow : Gtk.Grid {
 
     public signal void deleted ();
 
-    private const string FALLBACK_ICON = "application-default-icon";
-
     public AppChooserRow (Entity.AppInfo app_info) {
         Object (app_info: app_info);
     }
 
     construct {
-        var icon = new ThemedIcon.with_default_fallbacks (app_info.icon);
-        var icon_theme = Gtk.IconTheme.get_default ();
-
-        var image = new Gtk.Image ();
-        image.pixel_size = 32;
-
-        if (icon_theme.lookup_by_gicon (icon, 32, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
-            try {
-                var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon).scale_simple (32, 32, Gdk.InterpType.BILINEAR);
-                image = new Gtk.Image.from_pixbuf (pixbuf);
-            } catch (GLib.Error err) {
-                icon = new ThemedIcon (FALLBACK_ICON);
-                image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DND);
-                debug (err.message);
-            }
-        } else {
-            image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DND);
-        }
+        var image = Utils.create_icon (app_info, Gtk.IconSize.DND);
 
         var app_name = new Gtk.Label (app_info.name);
         app_name.get_style_context ().add_class ("h3");

--- a/src/Startup/Widgets/AppChooserRow.vala
+++ b/src/Startup/Widgets/AppChooserRow.vala
@@ -25,15 +25,31 @@ public class Startup.Widgets.AppChooserRow : Gtk.Grid {
 
     public signal void deleted ();
 
+    private const string FALLBACK_ICON = "application-default-icon";
+
     public AppChooserRow (Entity.AppInfo app_info) {
         Object (app_info: app_info);
     }
 
     construct {
-        var icon = Utils.create_icon (app_info);
+        var icon = new ThemedIcon.with_default_fallbacks (app_info.icon);
+        var icon_theme = Gtk.IconTheme.get_default ();
 
-        var image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.DND);
+        var image = new Gtk.Image ();
         image.pixel_size = 32;
+
+        if (icon_theme.lookup_by_gicon (icon, 32, Gtk.IconLookupFlags.USE_BUILTIN) == null) {
+            try {
+                var pixbuf = new Gdk.Pixbuf.from_file (app_info.icon).scale_simple (32, 32, Gdk.InterpType.BILINEAR);
+                image = new Gtk.Image.from_pixbuf ( pixbuf );
+            } catch (GLib.Error err) {
+                icon = new ThemedIcon (FALLBACK_ICON);
+                image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DND);
+                debug (err.message);
+            }
+        } else {
+            image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DND);
+        }
 
         var app_name = new Gtk.Label (app_info.name);
         app_name.get_style_context ().add_class ("h3");

--- a/src/Startup/Widgets/AppRow.vala
+++ b/src/Startup/Widgets/AppRow.vala
@@ -31,10 +31,7 @@ public class Startup.Widgets.AppRow : Gtk.ListBoxRow {
     }
 
     construct {
-        var icon = Utils.create_icon (app_info);
-
-        var image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.DIALOG);
-        image.pixel_size = 48;
+        var image = Utils.create_icon (app_info, Gtk.IconSize.DIALOG);
 
         var app_name = new Gtk.Label (app_info.name);
         app_name.get_style_context ().add_class ("h3");


### PR DESCRIPTION
Fixes https://github.com/elementary/switchboard-plug-applications/issues/27 in appchooser. The issue was due to apps using a file path as icon path.. The flatpak issue is no longer reproducible. Tested working for a set of flatpaks, snaps, appimages and debs and manually created deskop files (firefox nightly) with file path.

**Before**
![Screenshot from 2019-09-15 11-25-54](https://user-images.githubusercontent.com/14235191/64917311-6b890780-d7ac-11e9-9733-7a1c37a3f8dc.png)
![image](https://user-images.githubusercontent.com/14235191/64966446-6f0bb400-d8bc-11e9-9140-001eacb15153.png)

**After**
![Screenshot from 2019-09-15 11-24-54](https://user-images.githubusercontent.com/14235191/64917314-7ba0e700-d7ac-11e9-9207-d29cdc867c32.png)

![image](https://user-images.githubusercontent.com/14235191/64966391-500d2200-d8bc-11e9-95e6-1b7aa1505a78.png)


