### PR TITLE
Backend: get appinfo from id

### DIFF
--- a/src/Permissions/Backend/App.vala
+++ b/src/Permissions/Backend/App.vala
@@ -30,14 +30,7 @@ public class Permissions.Backend.App : GLib.Object {
     }
 
     construct {
-        var path = GLib.Path.build_filename (
-            AppManager.get_bundle_path_for_app (id),
-            "files",
-            "share",
-            "applications",
-            id + ".desktop"
-        );
-        var appinfo = new GLib.DesktopAppInfo.from_filename (path);
+        var appinfo = new GLib.DesktopAppInfo (id + ".desktop");
         name = appinfo.get_display_name ();
 
         settings = new GenericArray<Backend.PermissionSettings> ();


### PR DESCRIPTION
Seems like the code in master isn't returning a name reliably.

It's probably a rare case that a user has multiple apps with the same ID that return a different display name