### PR TITLE
Fix crash when no selected app.

### DIFF
--- a/src/Permissions/Backend/AppManager.vala
+++ b/src/Permissions/Backend/AppManager.vala
@@ -20,7 +20,7 @@
 */
 
 public class Permissions.Backend.AppManager : GLib.Object {
-    public string selected_app { get; set; }
+    public string selected_app { get; set; default = "";}
     public HashTable<string, Backend.App> apps { get; private set; }
     public string user_installation_path { get; private set; }
 

--- a/src/Permissions/Widgets/AppSettingsView.vala
+++ b/src/Permissions/Widgets/AppSettingsView.vala
@@ -142,6 +142,10 @@ public class Permissions.Widgets.AppSettingsView : Gtk.Grid {
         initialize_settings_view ();
 
         var app = Backend.AppManager.get_default ().apps.get (selected_app);
+        if (app == null) {
+            return;
+        }
+
         app.settings.foreach ((settings) => {
             foreach (unowned Gtk.Widget child in list_box.get_children ()) {
                 if (child is PermissionSettingsWidget) {


### PR DESCRIPTION
After recent updates this plug crashes when opening.

This fixes the immediate cause at least.