### PR TITLE
descriptive placeholder, insensitive view

### DIFF
--- a/src/Permissions/PermissionsPlug.vala
+++ b/src/Permissions/PermissionsPlug.vala
@@ -37,9 +37,29 @@ public class Permissions.Plug : Gtk.Grid {
     }
 
     construct {
+        var placeholder_title = new Gtk.Label (_("No Flatpak apps installed")) {
+            xalign = 0
+        };
+        placeholder_title.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+
+        var placeholder_description = new Gtk.Label (_("Apps whose permissions can be adjusted will automatically appear here when installed")) {
+            wrap = true,
+            xalign = 0
+        };
+
+        var placeholder = new Gtk.Grid () {
+            margin = 12,
+            row_spacing = 3,
+            valign = Gtk.Align.CENTER
+        };
+        placeholder.attach (placeholder_title, 0, 0);
+        placeholder.attach (placeholder_description, 0, 1);
+        placeholder.show_all ();
+
         var app_list = new Gtk.ListBox ();
         app_list.vexpand = true;
         app_list.selection_mode = Gtk.SelectionMode.SINGLE;
+        app_list.set_placeholder (placeholder);
         app_list.set_sort_func ((Gtk.ListBoxSortFunc) sort_func);
 
         var scrolled_window = new Gtk.ScrolledWindow (null, null);
@@ -63,8 +83,6 @@ public class Permissions.Plug : Gtk.Grid {
 
             app_list.select_row (row);
             show_row (row);
-        } else {
-            app_list.set_placeholder (new Gtk.Label (_("No Flatpak apps installed")));
         }
 
         column_spacing = 12;

--- a/src/Permissions/Widgets/AppSettingsView.vala
+++ b/src/Permissions/Widgets/AppSettingsView.vala
@@ -144,14 +144,7 @@ public class Permissions.Widgets.AppSettingsView : Gtk.Grid {
         initialize_settings_view ();
 
         if (selected_app == null) {
-            foreach (unowned Gtk.Widget child in list_box.get_children ()) {
-                if (child is PermissionSettingsWidget) {
-                    var widget = (PermissionSettingsWidget) child;
-                    widget.sensitive = false;
-                    widget.do_notify = true;
-                }
-            }
-
+            list_box.sensitive = false;
             reset_button.sensitive = false;
             return;
         }
@@ -161,7 +154,6 @@ public class Permissions.Widgets.AppSettingsView : Gtk.Grid {
                 if (child is PermissionSettingsWidget) {
                     var widget = (PermissionSettingsWidget) child;
                     if (widget.settings.context == settings.context) {
-                        widget.sensitive = true;
                         widget.do_notify = false;
                         widget.settings.standard = settings.standard;
                         widget.settings.enabled = settings.enabled;
@@ -170,6 +162,7 @@ public class Permissions.Widgets.AppSettingsView : Gtk.Grid {
                 }
             }
 
+            list_box.sensitive = true;
             reset_button.sensitive = true;
         });
     }


### PR DESCRIPTION
Listbox will automatically hide and show the placeholder as appropriate, so you don't need to only construct it if the list is empty. But you do need to make sure to call `show_all ()`

I made the whole listbox insensitive instead of just the switch. It's simpler and I think it's more clear too