### PR TITLE
SidebarRow: Get icon from appinfo

### DIFF
--- a/src/Permissions/Widgets/SidebarRow.vala
+++ b/src/Permissions/Widgets/SidebarRow.vala
@@ -29,7 +29,7 @@ public class Permissions.SidebarRow : Gtk.ListBoxRow {
     }
 
     construct {
-        var appinfo = new GLib.AppInfo (app.id + ".desktop");
+        var appinfo = new GLib.DesktopAppInfo (app.id + ".desktop");
 
         var image = new Gtk.Image.from_gicon (appinfo.get_icon (), Gtk.IconSize.DND);
         image.pixel_size = 32;

--- a/src/Permissions/Widgets/SidebarRow.vala
+++ b/src/Permissions/Widgets/SidebarRow.vala
@@ -29,7 +29,9 @@ public class Permissions.SidebarRow : Gtk.ListBoxRow {
     }
 
     construct {
-        var image = new Gtk.Image.from_icon_name (app.id, Gtk.IconSize.DND);
+        var appinfo = new GLib.AppInfo (app.id + ".desktop");
+
+        var image = new Gtk.Image.from_gicon (appinfo.get_icon (), Gtk.IconSize.DND);
         image.pixel_size = 32;
 
         var title_label = new Gtk.Label (app.name) {


### PR DESCRIPTION
The app icon name isn't always necessarily the same thing as the app ID, so we make sure we get the correct icon name from Appinfo