### PR TITLE
Compare app_infos correctly when adding a startup app

### DIFF
--- a/src/Startup/Entities/AppInfo.vala
+++ b/src/Startup/Entities/AppInfo.vala
@@ -26,4 +26,8 @@ public struct Startup.Entity.AppInfo {
     public string icon;
     public bool active;
     public string path;
+
+    public bool equal (Entity.AppInfo other_app_info) {
+        return this.name == other_app_info.name && this.path == other_app_info.path;
+    }
 }

--- a/src/Startup/Startup.vala
+++ b/src/Startup/Startup.vala
@@ -106,7 +106,7 @@ public class Startup.Plug : Gtk.Grid {
 
     public void add_app (Entity.AppInfo app_info) {
         foreach (unowned Gtk.Widget app_row in list.get_children ()) {
-            if (((Widgets.AppRow) app_row).app_info == app_info) {
+            if (((Widgets.AppRow) app_row).app_info.equal (app_info)) {
                 return;
             }
         }


### PR DESCRIPTION
Fixes #134 

Identify duplicate entries by comparing name and path not pointers to the app_info structs (which may differ)