### PR TITLE
Defaults: disallow focusing flowboxchild

### DIFF
--- a/src/Defaults/DefaultPlug.vala
+++ b/src/Defaults/DefaultPlug.vala
@@ -113,6 +113,7 @@ public class Defaults.Plug : Gtk.Box {
             box.add (setting_label);
             box.add (app_chooser);
 
+            can_focus = false;
             child = box;
 
             size_group.add_widget (setting_label);


### PR DESCRIPTION
We only want the combobox to be focusable, not the whole child