### PR TITLE
DefaultPlug: Set accessible name for combo boxes

### DIFF
--- a/src/Defaults/DefaultPlug.vala
+++ b/src/Defaults/DefaultPlug.vala
@@ -119,6 +119,8 @@ public class Defaults.Plug : Gtk.Box {
                 change_default (app_chooser.get_app_info (), content_type);
                 return null;
             }));
+
+            app_chooser.get_accessible ().accessible_name = "Default %s".printf (label);
         }
 
         private void run_in_thread (owned ThreadFunc<void*> func) {

--- a/src/Defaults/DefaultPlug.vala
+++ b/src/Defaults/DefaultPlug.vala
@@ -120,7 +120,8 @@ public class Defaults.Plug : Gtk.Box {
                 return null;
             }));
 
-            app_chooser.get_accessible ().accessible_name = "Default %s".printf (label);
+            // TRANSLATORS: This is description for for screen reader. %s can be "Web Browser" or "Music Player" and so on.
+            app_chooser.get_accessible ().accessible_name = _("Default %s").printf (label);
         }
 
         private void run_in_thread (owned ThreadFunc<void*> func) {


### PR DESCRIPTION
When focused, screen reader will read it as "Default `combobox name (e.g Web Browser or Music Player)` combo box. `Application name`"