### PR TITLE
DefaultPlug: revert audio content type

### DIFF
--- a/data/applications.metainfo.xml.in
+++ b/data/applications.metainfo.xml.in
@@ -35,6 +35,18 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="7.0.1" date="2023-08-24" urgency="medium">
+      <description>
+        <p>Minor updates:</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/music/issues/758">No music player set in applications settings</issue>
+      </issues>
+    </release>
+
     <release version="7.0.0" date="2023-06-26" urgency="medium">
       <description>
         <p>New features:</p>

--- a/src/Defaults/DefaultPlug.vala
+++ b/src/Defaults/DefaultPlug.vala
@@ -30,7 +30,7 @@ public class Defaults.Plug : Gtk.Box {
 
         var music_setting = new SettingsChild (
             _("Music Player"),
-            "x-content/audio-player"
+            "audio/x-vorbis+ogg"
         );
 
         var images_setting = new SettingsChild (
@@ -204,7 +204,7 @@ public class Defaults.Plug : Gtk.Box {
                         "video/x-ogm+ogg"
                     };
 
-                case "x-content/audio-player":
+                case "audio/x-vorbis+ogg":
                     return {
                         "audio/ogg",
                         "audio/mpeg",
@@ -264,7 +264,8 @@ public class Defaults.Plug : Gtk.Box {
                         "audio/midi",
                         "audio/x-scpls",
                         "audio/webm",
-                        "audio/x-webm"
+                        "audio/x-webm",
+                        "x-content/audio-player"
                     };
 
                 case "image/jpeg":


### PR DESCRIPTION
Revert change from #193 

Fixes https://github.com/elementary/music/issues/758

Music does have this content type in the desktop file, but for some reason it's not working