### PR TITLE
AppSettingsView: use AppInfo description

### DIFF
--- a/src/Permissions/Backend/App.vala
+++ b/src/Permissions/Backend/App.vala
@@ -25,6 +25,7 @@ public class Permissions.Backend.App : GLib.Object {
     public Flatpak.InstalledRef installed_ref { get; construct; }
     public string id { get; private set; }
     public string name { get; private set; }
+    public string? description { get; private set; default = null; }
     public Icon icon { get; private set; }
     public GenericArray<Backend.PermissionSettings> settings;
 
@@ -41,6 +42,7 @@ public class Permissions.Backend.App : GLib.Object {
         if (appinfo != null) {
             name = appinfo.get_name ();
             icon = appinfo.get_icon () ?? new ThemedIcon ("application-default-icon");
+            description = appinfo.get_description ();
         } else {
             icon = new ThemedIcon ("application-default-icon");
             name = id;

--- a/src/Permissions/Widgets/AppSettingsView.vala
+++ b/src/Permissions/Widgets/AppSettingsView.vala
@@ -187,6 +187,7 @@ public class Permissions.Widgets.AppSettingsView : Switchboard.SettingsPage {
 
         update_property (Gtk.AccessibleProperty.LABEL, _("%s permissions").printf (selected_app.name), -1);
         title = selected_app.name;
+        description = selected_app.description;
         icon = selected_app.icon;
     }
 


### PR DESCRIPTION
![Screenshot from 2024-03-29 09 16 24](https://github.com/elementary/switchboard-plug-applications/assets/7277719/c7dc7b9e-1a16-4caf-bee6-3bacaafccf42)

As requested by @DavidNielsen