### PR TITLE
Control: fix maintainer field

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: io.elementary.settings.applications
 Section: x11
 Priority: optional
-Maintainer: elementary, Inc. <builds@elementary.io>
+Maintainer: elementary <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                gettext,
                libadwaita-1-dev,


### PR DESCRIPTION
Builds on Resolute is failing due to this: https://code.launchpad.net/~elementary-os/+recipe/settings-applications-daily

```
dpkg-buildpackage: info: source package io.elementary.settings.applications
dpkg-buildpackage: info: source version 8.3.0+r1463+pkg398~daily~ubuntu26.04.1
dpkg-buildpackage: info: source distribution resolute
dpkg-buildpackage: info: source changed by Launchpad Package Builder <noreply@launchpad.net>
 dpkg-source -i -I.bzr -I.git --before-build .
dpkg-source: error: cannot parse Maintainer field value "elementary, Inc. <builds@elementary.io>"
dpkg-buildpackage: error: dpkg-source -i -I.bzr -I.git --before-build . subprocess failed with exit status 25
[Sun Mar 22 20:07:05 2026]
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=chroot --series=resolute --abi-tag=amd64 --isa-tag=amd64 RECIPEBRANCHBUILD-4021568
Scanning for processes to kill in build RECIPEBRANCHBUILD-4021568
```